### PR TITLE
chore: release v0.14.0

### DIFF
--- a/.changeset/free-games-stare.md
+++ b/.changeset/free-games-stare.md
@@ -1,5 +1,0 @@
----
-"@mp-lb/zapper": minor
----
-
-Env var mgmt, volume isolation, ls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mp-lb/zapper
 
+## 0.14.0
+
+### Minor Changes
+
+- 794bc6f: Env var mgmt, volume isolation, ls
+
 ## 0.13.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mp-lb/zapper",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A lightweight dev environment runner for local multi-service projects",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Manual Version Packages PR because the Release workflow cannot create PRs with the current repository Actions setting.

Verification run locally on this branch:
- pnpm build
- pnpm test:e2e
- pnpm test
- pnpm lint:fix

This consumes the changeset and prepares @mp-lb/zapper v0.14.0 for publish.